### PR TITLE
JS Hint Rules

### DIFF
--- a/public/skin/frontend/session/default/gulpfile.js
+++ b/public/skin/frontend/session/default/gulpfile.js
@@ -132,7 +132,16 @@ gulp.task('build-theme-scripts', function () {
         './js/session_modules/*.js',
         '!./js/**/*.min.js'
     ])
-        .pipe($.jshint())
+        .pipe($.jshint({
+            globalstrict: true,
+            globals: {
+                'require': false,
+                'window': false,
+                'module': true,
+                'document': false,
+                '$': true
+            }
+        }))
         .pipe($.jshint.reporter('jshint-stylish'));
 
     /**

--- a/public/skin/frontend/session/default/gulpfile.js
+++ b/public/skin/frontend/session/default/gulpfile.js
@@ -129,7 +129,8 @@ gulp.task('build-theme-scripts', function () {
     /* jshint */
     gulp.src([
         './js/*.js',
-        './js/session_modules/*.js'
+        './js/session_modules/*.js',
+        '!./js/**/*.min.js'
     ])
         .pipe($.jshint())
         .pipe($.jshint.reporter('jshint-stylish'));


### PR DESCRIPTION
Just some JS Hint rules so gulp doesn't cough up loads of errors whenever it's run. Left all as defaults apart from globalstrict (I believe webpack encapsulates the modules so wrapping modules in a function is not required?) and added some globals that seem to be widely used.
