### PR TITLE
Move the Magento crypt_key from chef-magento to chef config

### DIFF
--- a/tools/chef/Berksfile.lock
+++ b/tools/chef/Berksfile.lock
@@ -2,7 +2,7 @@ DEPENDENCIES
   apache2 (~> 1.8.14)
   chef-magento
     git: git://github.com/inviqa/chef-magento.git
-    revision: 5a78f18cf6a30eeaa62cfe5e6182096309b438eb
+    revision: 1f42b3dbdedfbc36cb9608dd304c583d307bfd01
     tag: 1.0.4
   chef-php-extra
     git: git://github.com/inviqa/chef-php-extra.git

--- a/tools/chef/data_bags/environments/development.json
+++ b/tools/chef/data_bags/environments/development.json
@@ -16,6 +16,9 @@
     }
   },
   "magento": {
+    "app": {
+      "crypt_key": "82ba7f3f9db9aec288ffbce1e0ad08e2"
+    },
     "db": {
       "password": "magento"
     }


### PR DESCRIPTION
chef-magento is being rebased to apply a security fix across every commit.
The commit ref is therefore changing for each tag
