### PR TITLE
DEVOPS-479 switch to dot test for local vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the root directory:
 
     hobo vm up
 
-In your browser of choice, your VM will be available at [http://mast.dev](http://mast.dev).
+In your browser of choice, your VM will be available at [http://mast.test](http://mast.test).
 
 ## Using it in a project
 
@@ -85,7 +85,7 @@ For information on Atomic Design and documentation for pattern lab, visit the [P
 
 #### Viewing the style guide
 
-After gulp is run for the first time, a style guide will be generated at [http://mast.dev/style-guide/index.html](http://mast.dev/style-guide/index.html).
+After gulp is run for the first time, a style guide will be generated at [http://mast.test/style-guide/index.html](http://mast.test/style-guide/index.html).
 
 #### Updating the style guide
 

--- a/public/skin/frontend/session/default/gulpfile.js
+++ b/public/skin/frontend/session/default/gulpfile.js
@@ -1,7 +1,7 @@
 /* set theme name and paths */
 
 var themeName = 'session',
-    themeURL = 'mast.dev',
+    themeURL = 'mast.test',
     publicJsDir = '../../../../js/',
     toolsDir = '../../../../../tools/',
     patternLabDir = 'pattern-lab/'

--- a/tools/capistrano/config/deploy/dev.rb
+++ b/tools/capistrano/config/deploy/dev.rb
@@ -2,4 +2,4 @@ set :deploy_to, "/tmp/test" # Deploys to VM not presently supported
 set :branch, "develop"
 
 ssh_options[:keys] = [File.join(ENV['HOME'], '.vagrant.d', 'insecure_private_key')]
-server "vagrant@mast.dev", :app, :primary => true
+server "vagrant@mast.test", :app, :primary => true

--- a/tools/chef/Berksfile
+++ b/tools/chef/Berksfile
@@ -5,7 +5,7 @@ source 'https://api.berkshelf.com'
 cookbook 'yum', '~> 3.3.2'
 cookbook 'yum-epel', '~> 0.5.1'
 cookbook 'yum-ius', '~> 0.3.0'
-cookbook 'mysql', '~> 4.0.20'
+cookbook 'mysql', '~> 4.1.2'
 cookbook 'php', '~> 1.3.12'
 cookbook 'redisio', '~> 1.7.1'
 cookbook 'memcached', '~> 1.7.2'
@@ -16,12 +16,21 @@ cookbook 'data-bag-merge', '~> 0.1.3'
 
 cookbook 'jetty', :github => 'inviqa/chef-jetty', :tag => '0.2'
 cookbook 'solr', :github => 'inviqa/chef-solr', :tag => '1.0.1'
-cookbook 'chef-varnish', :github => 'inviqa/chef-varnish', :ref => '1.0.5'
-cookbook 'config-driven-helper', :github => 'inviqa/chef-config-driven-helper', :ref => '1.3.2'
+cookbook 'chef-varnish', :github => 'inviqa/chef-varnish', :ref => '2.1.0'
 cookbook 'php-fpm', :github => 'inviqa/cookbook-php-fpm', :tag => '0.6.11'
+cookbook 'config-driven-helper', '~> 2.5'
 
 cookbook 'project', :path => 'site-cookbooks/project'
 
+# Pin cookbooks to avoid bringing in chef 12+ code
+cookbook 'aws', '~> 2.7.2'
+cookbook 'dmg', '~> 2.2.2'
+cookbook 'homebrew', '~> 1.10.0'
+cookbook 'git', '~> 4.2.2'
+cookbook 'iis', '~> 4.1.1'
+cookbook 'iptables', '~> 1.0.0'
+cookbook 'rsyslog', '~> 2.2.0'
+
 # Please try to avoid using anything from these. They may be deprecated soon.
-cookbook 'chef-magento', :github => 'inviqa/chef-magento', :tag => '1.0.4'
+cookbook 'chef-magento', :github => 'inviqa/chef-magento', :tag => '1.1.0'
 cookbook 'chef-php-extra', :github => 'inviqa/chef-php-extra', :tag => '0.4.1-legacy-upgrade'

--- a/tools/chef/Berksfile.lock
+++ b/tools/chef/Berksfile.lock
@@ -1,29 +1,32 @@
 DEPENDENCIES
   apache2 (~> 1.8.14)
+  aws (~> 2.7.2)
   chef-magento
     git: git://github.com/inviqa/chef-magento.git
-    revision: 1f42b3dbdedfbc36cb9608dd304c583d307bfd01
-    tag: 1.0.4
+    revision: e290e2222c23b77136a2e0641fdacf5b8e22fbac
+    tag: 1.1.0
   chef-php-extra
     git: git://github.com/inviqa/chef-php-extra.git
     revision: 844de2716d5cd53a93cfdab77c41a891f72bc435
     tag: 0.4.1-legacy-upgrade
   chef-varnish
     git: git://github.com/inviqa/chef-varnish.git
-    revision: b648abfb373d3cdac67f89d89f14944a265657a0
-    ref: 1.0.5
-  config-driven-helper
-    git: git://github.com/inviqa/chef-config-driven-helper.git
-    revision: 84905213f2388d5ddf865f5c831c4fb343179dc9
-    ref: 1.3.2
+    revision: b75b32ef89ad339f1476ba2121017a0ef606feaa
+    ref: 2.1.0
+  config-driven-helper (~> 2.5)
   data-bag-merge (~> 0.1.3)
+  dmg (~> 2.2.2)
   elasticsearch (~> 0.3.7)
+  git (~> 4.2.2)
+  homebrew (~> 1.10.0)
+  iis (~> 4.1.1)
+  iptables (~> 1.0.0)
   jetty
     git: git://github.com/inviqa/chef-jetty.git
     revision: de58c6923d4c6387deabb7ace92ee051a408328d
     tag: 0.2
   memcached (~> 1.7.2)
-  mysql (~> 4.0.20)
+  mysql (~> 4.1.2)
   nginx (= 2.4.2)
   php (~> 1.3.12)
   php-fpm
@@ -33,6 +36,7 @@ DEPENDENCIES
   project
     path: site-cookbooks/project
   redisio (~> 1.7.1)
+  rsyslog (~> 2.2.0)
   solr
     git: git://github.com/inviqa/chef-solr.git
     revision: da9112f7b6f330e9d04467b186228f3f38f1cfe9
@@ -42,22 +46,21 @@ DEPENDENCIES
   yum-ius (~> 0.3.0)
 
 GRAPH
-  7-zip (1.0.2)
-    windows (>= 1.2.2)
   apache2 (1.8.14)
-  apt (2.6.1)
-  ark (0.9.0)
-    7-zip (>= 0.0.0)
+  apt (2.9.2)
+  ark (3.1.0)
+    build-essential (>= 0.0.0)
+    seven_zip (>= 0.0.0)
     windows (>= 0.0.0)
-  aws (2.5.0)
-  bluepill (2.3.1)
-    rsyslog (>= 0.0.0)
+  aws (2.7.2)
+  bluepill (2.4.3)
+    rsyslog (>= 2.0)
   build-essential (1.4.4)
-  chef-magento (1.0.4)
+  chef-magento (1.1.0)
     apache2 (>= 0.0.0)
     chef-php-extra (>= 0.0.0)
     chef-varnish (>= 0.0.0)
-    cron (~> 1.4.0)
+    cron (~> 1.4)
     database (> 1.3.0)
     git (>= 0.0.0)
     memcached (>= 0.0.0)
@@ -67,17 +70,18 @@ GRAPH
   chef-php-extra (0.4.1-legacy-upgrade)
     apt (>= 1.8.4)
     git (>= 1.0.0)
-  chef-sugar (2.5.0)
-  chef-varnish (1.0.5)
+  chef-varnish (2.1.0)
     apt (>= 0.0.0)
+    packagecloud (~> 0.3.0)
     yum (>= 0.0.0)
-  chef_handler (1.1.6)
-  config-driven-helper (1.3.2)
-    apache2 (~> 1.8.14)
-    build-essential (~> 1.4.4)
+  config-driven-helper (2.7.0)
+    apache2 (>= 1.8)
+    build-essential (~> 1.4)
     database (~> 2.0.0)
-    mysql (~> 4.0.20)
-  cron (1.4.3)
+    iptables-ng (>= 2.2)
+    mysql (~> 4.0)
+    nginx (< 2.4.4)
+  cron (1.7.6)
   data-bag-merge (0.1.4)
   database (2.0.0)
     aws (>= 0.0.0)
@@ -85,23 +89,22 @@ GRAPH
     postgresql (>= 1.0.0)
     xfs (>= 0.0.0)
   dmg (2.2.2)
-  elasticsearch (0.3.13)
+  elasticsearch (0.3.14)
     ark (>= 0.2.4)
-    build-essential (>= 0.0.0)
-    java (>= 0.0.0)
-    monit (>= 0.0.0)
-    xml (>= 0.0.0)
-  git (4.1.0)
+  git (4.2.4)
     build-essential (>= 0.0.0)
     dmg (>= 0.0.0)
-    runit (>= 1.0)
     windows (>= 0.0.0)
-    yum (~> 3.0)
     yum-epel (>= 0.0.0)
-  iis (2.1.6)
+  homebrew (1.10.0)
+  iis (4.1.10)
     windows (>= 1.34.6)
-  iptables (0.14.1)
-  java (1.29.0)
+  iptables (1.0.0)
+  iptables-ng (3.0.0)
+  java (1.50.0)
+    apt (>= 0.0.0)
+    homebrew (>= 0.0.0)
+    windows (>= 0.0.0)
   jetty (0.2.0)
     iptables (>= 0.0.0)
     java (>= 0.0.0)
@@ -109,10 +112,11 @@ GRAPH
     runit (~> 1.0)
     yum (~> 3.0)
     yum-epel (>= 0.0.0)
-  monit (0.7.5)
-  mysql (4.0.20)
+  mysql (4.1.2)
     build-essential (~> 1.4)
+    homebrew (>= 0.0.0)
     openssl (~> 1.1)
+    windows (>= 0.0.0)
   nginx (2.4.2)
     apt (~> 2.2)
     bluepill (~> 2.3)
@@ -123,6 +127,7 @@ GRAPH
     yum-epel (>= 0.0.0)
   ohai (1.1.12)
   openssl (1.1.0)
+  packagecloud (0.3.0)
   php (1.3.14)
     build-essential (>= 0.0.0)
     iis (>= 0.0.0)
@@ -133,27 +138,26 @@ GRAPH
   php-fpm (0.6.11)
     apt (>= 0.0.0)
     yum (>= 3.0.0)
-  postgresql (3.4.14)
+  postgresql (3.4.16)
     apt (>= 1.9.0)
     build-essential (>= 0.0.0)
     openssl (>= 0.0.0)
   project (0.0.1)
   redisio (1.7.1)
     ulimit (>= 0.1.2)
-  rsyslog (1.13.0)
-  runit (1.5.14)
-    build-essential (>= 0.0.0)
-    yum (~> 3.0)
+  rsyslog (2.2.0)
+  runit (1.8.0)
+    packagecloud (>= 0.0.0)
     yum-epel (>= 0.0.0)
+  seven_zip (2.0.2)
+    windows (>= 1.2.2)
   solr (1.0.0)
     jetty (>= 0.0.0)
-  ulimit (0.3.2)
-  windows (1.36.1)
-    chef_handler (>= 0.0.0)
-  xfs (1.1.0)
-  xml (1.2.9)
+  ulimit (0.4.0)
+  windows (2.0.2)
+  xfs (2.0.1)
+  xml (3.1.2)
     build-essential (>= 0.0.0)
-    chef-sugar (>= 0.0.0)
   yum (3.3.2)
   yum-epel (0.5.3)
     yum (~> 3.0)

--- a/tools/chef/environments/development.json
+++ b/tools/chef/environments/development.json
@@ -8,7 +8,7 @@
     "nginx": {
       "sites": {
         "mast": {
-          "server_name": "mast.dev",
+          "server_name": "mast.test",
           "docroot": "/vagrant/public",
           "protocols": ["http", "https"],
           "restricted_dirs":  [

--- a/tools/chef/roles/web-nginx.json
+++ b/tools/chef/roles/web-nginx.json
@@ -31,9 +31,13 @@
     "services": {
       "nginx": ["enable", "start"],
       "php-fpm": ["enable", "start"]
+    },
+    "packages-additional": {
+      "nginx": "upgrade"
     }
   },
   "run_list": [
+    "recipe[config-driven-helper::packages-additional]",
     "recipe[nginx]",
     "recipe[php-fpm]",
     "recipe[config-driven-helper::services]",

--- a/tools/hobo/config.yaml
+++ b/tools/hobo/config.yaml
@@ -6,7 +6,7 @@
   :url: git@github.com:inviqa/hobo-seed-magento
   :version: 3ea421a
 :vm_ip: 10.56.62.222
-:hostname: mast.dev
+:hostname: mast.test
 :asset_bucket: inviqa-assets-mast
 :vm:
   :project_mount_path: "/vagrant"

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.require_version ">= 1.5.0"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # vagrant-hostsupdater settings
-  config.vm.hostname = "mast.dev"
+  config.vm.hostname = "mast.test"
   # config.hostsupdater.aliases = []
 
   # vagrant-omnibus settings

--- a/tools/vagrant/spec/host_spec.rb
+++ b/tools/vagrant/spec/host_spec.rb
@@ -5,7 +5,7 @@ require 'yaml'
 hosts = Resolv::Hosts.new
 config = YAML::load_file("../hobo/config.yaml")
 describe "Host" do
-  it "mast.dev should route to #{config[:vm_ip]}" do
-    hosts.getaddress("mast.dev").to_s.should eq config[:vm_ip]
+  it "mast.test should route to #{config[:vm_ip]}" do
+    hosts.getaddress("mast.test").to_s.should eq config[:vm_ip]
   end
 end

--- a/tools/vagrant/spec/httpd_spec.rb
+++ b/tools/vagrant/spec/httpd_spec.rb
@@ -14,13 +14,13 @@ describe port(80) do
   it { should be_listening }
 end
 
-describe file('/etc/nginx/sites-enabled/mast.dev') do
+describe file('/etc/nginx/sites-enabled/mast.test') do
   it { should be_file }
-  its(:content) { should match /server_name .*mast.dev.*/ }
+  its(:content) { should match /server_name .*mast.test.*/ }
 end
 
 describe "HTTP OK" do
   it do
-    Net::HTTP.get_response(URI.parse('http://mast.dev')).should be_a Net::HTTPOK
+    Net::HTTP.get_response(URI.parse('http://mast.test')).should be_a Net::HTTPOK
   end
 end


### PR DESCRIPTION
Chrome will soon start forcing HSTS for .dev domains which needs a real SSL certificate, so in order to mitigate issues that this will cause, we are switching out .dev for .test.

Please see more information on Google's plans here:
https://security.googleblog.com/2017/09/broadening-hsts-to-secure-more-of-web.html